### PR TITLE
Fix setting recordings_filename.

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -380,6 +380,7 @@ void addbinding(int keycode, int mods, char *commands) {
                 "set it to '%s'. Keeping original value.\n",
                 recordings_filename, path);
       } else {
+        recordings_filename = newrecordingpath;
         parse_recordings(recordings_filename);
       }
     }


### PR DESCRIPTION
Setting a recording filename did not work at all, because the filename
value of the configuration line was thrown away **and** not freed. So i
suppose it was just forgotten to set.
