### PR TITLE
Add some support for XDG Base Directory.

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -444,6 +444,19 @@ void parse_config() {
   defaults();
   parse_config_file(GLOBAL_CONFIG_FILE);
   parse_config_file("~/.keynavrc");
+
+  // support XDG Base Directory
+  char *config_home = getenv("XDG_CONFIG_HOME");
+  char *user_config_file;
+
+  if (config_home &&
+      asprintf(&user_config_file, "%s/keynav/keynavrc", config_home) != -1) {
+    parse_config_file(user_config_file);
+    free(user_config_file);
+  } else {
+    // standard default if XDG_CONFIG_HOME is not set
+    parse_config_file("~/.config/keynav/keynavrc");
+  }
 }
 
 void defaults() {

--- a/keynav.pod
+++ b/keynav.pod
@@ -27,7 +27,9 @@ Another example: daemonize on startup:
 =head1 CONFIGURATION
 
 keynav is configured by default from a config file in your home directory
-"~/.keynavrc"
+"~/.keynavrc" or "$XDG_CONFIG_HOME/keynav/keynavrc" per the XDG Base Directory
+standard (defaulting to "~/.config/keynav/keynavrc" if XDG_CONFIG_HOME is not
+set).
 
 The default configuration can be found in the L<DEFAULT CONFIGURATION> section.
 


### PR DESCRIPTION
This implements partial support for the [XDG Base Directory](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) standard, adding an additional config location `$XDG_CONFIG_HOME/keynav/keynavrc` (with `XDG_CONFIG_HOME` defaulting to `~/.config` in case it's not set). In case you haven't heard of it, the intent of the standard is to have a standard mechanism for specifying the location of config (and data, and cache) files for programs and to clean up the home directory of dotfiles. The support is partial because this patch only specifies an alternative location for the user's config file (i.e. it doesn't respect `XDG_CONFIG_DIRS`).
