### PR TITLE
suppress warning about asprintf

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -5,6 +5,8 @@
  *      same as wininfo, so use that instead.
  */
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
otherwise you get the following from make:

```
keynav.c: In function ‘addbinding’:
keynav.c:376:9: warning: implicit declaration of function ‘asprintf’; did you mean ‘vsprintf’? [-Wimplicit-function-declaration]
         asprintf(&newrecordingpath, "%s/%s", getenv("HOME"), path + 2);
         ^~~~~~~~
         vsprintf
```