### PR TITLE
Direct support for mod1-5 (resolves issue #19)

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -319,6 +319,16 @@ int parse_mods(char *keyseq) {
     if ((keysym == XK_Super_L) || (keysym == XK_Super_R)
         || (keysym == XK_Hyper_L) || (keysym == XK_Hyper_R))
       modmask |= Mod4Mask;
+    if (!strcasecmp(mod, "mod1"))
+      modmask |= Mod1Mask;
+    if (!strcasecmp(mod, "mod2"))
+      modmask |= Mod2Mask;
+    if (!strcasecmp(mod, "mod3"))
+      modmask |= Mod3Mask;
+    if (!strcasecmp(mod, "mod4"))
+      modmask |= Mod4Mask;
+    if (!strcasecmp(mod, "mod5"))
+      modmask |= Mod5Mask;
 
     /* 'xmodmap' will output the current modN:KeySym mappings */
   }


### PR DESCRIPTION
I hope there is a better (without copy-paste) way to write this, but for
now this will do.

Basically, we need to support at least mod3 and mod4 so that people can
start keynav using Hyper and Super keys. Given that there is no
universally fixed modifier bit for these keys, we can't just make
“hyper” and “super” strings work. Other modifiers (1,2,5) are added for
consistency, and also because somebody may actually need them.