### PR TITLE
Adding libxrandr-dev in README compiling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compiling
 
 You may need some extra libraries to compile keynav.  On Debian and Ubuntu you can install these packages:
 
-    sudo apt-get install libcairo2-dev libxinerama-dev libxdo-dev
+    sudo apt-get install libcairo2-dev libxinerama-dev libxdo-dev libxrandr-dev
 
 Next you simply run make:
 


### PR DESCRIPTION
When I was compiling, I received libxrandr-related error messages, which were not found in Ubuntu 18.04.3 LTS.