### PR TITLE
Fix bug - not being able to click when cursor is on grid line of keynav

### DIFF
--- a/keynav.c
+++ b/keynav.c
@@ -984,6 +984,10 @@ void cmd_start(char *args) {
     winattr.override_redirect = 1;
     XChangeWindowAttributes(dpy, zone, CWOverrideRedirect, &winattr);
 
+    /* Set the input shape to be nothing so that the cursor can still
+     * click or scroll while it's on the keynav grid */
+    XShapeCombineRectangles(dpy, zone, ShapeInput, 0, 0, NULL, 0, ShapeSet, 0);
+
     XSelectInput(dpy, zone, StructureNotifyMask | ExposureMask
                  | PointerMotionMask | LeaveWindowMask );
   } /* if zone == 0 */


### PR DESCRIPTION
When cursor happens to exactly be on top of the line drawn by keynav, clicking (click command from .keynavrc) doesn't work. This is the fix.

Steps to reproduce:


```
Super+space start, grid 4x3
h warp,end,start , grid 4x3
1 click 1
```

1. Press Super+space : the grid is 4x3 appears over entire screen.
2. Press h : now the cursor is right in the middle of the screen, **over the vertical line of keynav**.
3. Press 1 : there should be a click on the position where the cursor is. But, **because the cursor is over the line drawn by keynav, no click happens**. *It's as if the cursor over keynav clicks the keynav "window" itself, rather than the actual application beneath the keynav frame*.

Additional notes:
- I use 4x3 instead of 3x3, because I have my 4 fingers of the `jkl;` keys of the keyboard home row, and want to use all of them.